### PR TITLE
chore: add standards-version frontmatter to skills and rules

### DIFF
--- a/rules/cfx-csharp-conventions.mdc
+++ b/rules/cfx-csharp-conventions.mdc
@@ -3,6 +3,7 @@ title: CFX C# conventions
 description: Coding conventions for C# scripts in FiveM and RedM resources
 globs: ["**/*.cs", "**/*.csproj"]
 alwaysApply: false
+standards-version: 1.6.3
 ---
 
 # CFX C# conventions

--- a/rules/cfx-javascript-conventions.mdc
+++ b/rules/cfx-javascript-conventions.mdc
@@ -3,6 +3,7 @@ title: CFX JavaScript conventions
 description: Coding conventions for JavaScript scripts in FiveM and RedM resources
 globs: ["**/*.js", "**/*.ts"]
 alwaysApply: false
+standards-version: 1.6.3
 ---
 
 # CFX JavaScript conventions

--- a/rules/cfx-lua-conventions.mdc
+++ b/rules/cfx-lua-conventions.mdc
@@ -3,6 +3,7 @@ title: CFX Lua conventions
 description: Coding conventions for Lua scripts in FiveM and RedM resources
 globs: ["**/*.lua"]
 alwaysApply: false
+standards-version: 1.6.3
 ---
 
 # CFX Lua conventions

--- a/rules/fxmanifest-standards.mdc
+++ b/rules/fxmanifest-standards.mdc
@@ -3,6 +3,7 @@ title: fxmanifest standards
 description: Standards for FiveM/RedM resource manifest files
 globs: ["**/fxmanifest.lua"]
 alwaysApply: true
+standards-version: 1.6.3
 ---
 
 # fxmanifest.lua standards

--- a/rules/performance-rules.mdc
+++ b/rules/performance-rules.mdc
@@ -3,6 +3,7 @@ title: Performance rules
 description: Performance optimization rules for CFX resources
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
 alwaysApply: true
+standards-version: 1.6.3
 ---
 
 # CFX performance rules

--- a/rules/security-best-practices.mdc
+++ b/rules/security-best-practices.mdc
@@ -3,6 +3,7 @@ title: Security best practices
 description: Security rules for FiveM/RedM resource development
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
 alwaysApply: false
+standards-version: 1.6.3
 ---
 
 # CFX security best practices

--- a/skills/client-server-patterns/SKILL.md
+++ b/skills/client-server-patterns/SKILL.md
@@ -2,6 +2,7 @@
 title: Client-Server Patterns
 description: Correct patterns for client/server scripting in Lua, JavaScript, and C# for CFX
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
+standards-version: 1.6.3
 ---
 
 # Client-Server Patterns

--- a/skills/database-integration/SKILL.md
+++ b/skills/database-integration/SKILL.md
@@ -2,6 +2,7 @@
 title: Database Integration
 description: Guide database setup and queries for FiveM/RedM resources using oxmysql
 globs: ["**/*.lua", "**/*.js", "**/*.sql"]
+standards-version: 1.6.3
 ---
 
 # Database Integration

--- a/skills/framework-detection/SKILL.md
+++ b/skills/framework-detection/SKILL.md
@@ -2,6 +2,7 @@
 title: Framework Detection
 description: Detect which framework a project is using and adapt code generation accordingly
 globs: ["**/fxmanifest.lua", "**/*.lua"]
+standards-version: 1.6.3
 ---
 
 # Framework Detection

--- a/skills/fxmanifest/SKILL.md
+++ b/skills/fxmanifest/SKILL.md
@@ -2,6 +2,7 @@
 title: fxmanifest.lua Expert
 description: Expert knowledge on writing and editing FiveM/RedM resource manifest files
 globs: ["**/fxmanifest.lua"]
+standards-version: 1.6.3
 ---
 
 # fxmanifest.lua Expert

--- a/skills/native-functions/SKILL.md
+++ b/skills/native-functions/SKILL.md
@@ -2,6 +2,7 @@
 title: Native Function Lookup
 description: Help the AI agent find and correctly use FiveM and RedM native functions
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
+standards-version: 1.6.3
 ---
 
 # Native Function Lookup

--- a/skills/nui-development/SKILL.md
+++ b/skills/nui-development/SKILL.md
@@ -2,6 +2,7 @@
 title: NUI Development
 description: Guide development of NUI (in-game web UI) interfaces for FiveM and RedM
 globs: ["**/fxmanifest.lua", "**/*.html", "**/*.css"]
+standards-version: 1.6.3
 ---
 
 # NUI Development

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -2,6 +2,7 @@
 title: Performance Optimization
 description: CFX-specific performance best practices for FiveM and RedM resources
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
+standards-version: 1.6.3
 ---
 
 # Performance Optimization

--- a/skills/resource-scaffolding/SKILL.md
+++ b/skills/resource-scaffolding/SKILL.md
@@ -2,6 +2,7 @@
 title: Resource Scaffolding
 description: Guide the AI agent through creating a new FiveM or RedM resource from scratch
 globs: ["**/fxmanifest.lua"]
+standards-version: 1.6.3
 ---
 
 # Resource Scaffolding

--- a/skills/state-bags/SKILL.md
+++ b/skills/state-bags/SKILL.md
@@ -2,6 +2,7 @@
 title: State Bags
 description: Modern data synchronization using State Bags instead of TriggerClientEvent patterns
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
+standards-version: 1.6.3
 ---
 
 # State Bags


### PR DESCRIPTION
Phase 1 of the drift-checker work. Mechanical addition of `standards-version: 1.6.3` to all SKILL.md and .mdc files. See TMHSDigital/Developer-Tools-Directory#1.
