### PR TITLE
chore: add standards-version marker to agent context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
+<!-- standards-version: 1.6.3 -->
+
 # AGENTS.md
 
 This file tells AI coding agents how the CFX Developer Tools repo works and how to contribute correctly.


### PR DESCRIPTION
Companion to the skill/rule rollout from 2026-04-24. Adds HTML comment marker `<!-- standards-version: 1.6.3 -->` to AGENTS.md and CLAUDE.md in this repo. See TMHSDigital/Developer-Tools-Directory#1.
