### PR TITLE
fix: paths-ignore should exclude agent files from release triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
       - "*.md"
       - "LICENSE"
       - "mkdocs.yml"
+      - "skills/**"
+      - "rules/**/*.mdc"
+      - "AGENTS.md"
+      - "CLAUDE.md"
 
 permissions:
   contents: write


### PR DESCRIPTION
Expands paths-ignore in release.yml to exclude agent files (skills, rules, AGENTS.md, CLAUDE.md) from triggering releases. The current `*.md` filter does not match subdirectory files due to GitHub Actions glob semantics.

Prerequisite for Phase 2 Session D signal rollout.
