### PR TITLE
feat: align with ecosystem standards v1.7.0 and add drift-check CI

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -1,0 +1,21 @@
+name: Ecosystem drift check
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  drift-check:
+    name: Ecosystem drift check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: TMHSDigital/Developer-Tools-Directory/.github/actions/drift-check@v1.7
+        with:
+          mode: self
+          format: gh-summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- standards-version: 1.6.3 -->
+<!-- standards-version: 1.7.0 -->
 
 # AGENTS.md
 

--- a/rules/cfx-csharp-conventions.mdc
+++ b/rules/cfx-csharp-conventions.mdc
@@ -3,7 +3,7 @@ title: CFX C# conventions
 description: Coding conventions for C# scripts in FiveM and RedM resources
 globs: ["**/*.cs", "**/*.csproj"]
 alwaysApply: false
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # CFX C# conventions

--- a/rules/cfx-javascript-conventions.mdc
+++ b/rules/cfx-javascript-conventions.mdc
@@ -3,7 +3,7 @@ title: CFX JavaScript conventions
 description: Coding conventions for JavaScript scripts in FiveM and RedM resources
 globs: ["**/*.js", "**/*.ts"]
 alwaysApply: false
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # CFX JavaScript conventions

--- a/rules/cfx-lua-conventions.mdc
+++ b/rules/cfx-lua-conventions.mdc
@@ -3,7 +3,7 @@ title: CFX Lua conventions
 description: Coding conventions for Lua scripts in FiveM and RedM resources
 globs: ["**/*.lua"]
 alwaysApply: false
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # CFX Lua conventions

--- a/rules/fxmanifest-standards.mdc
+++ b/rules/fxmanifest-standards.mdc
@@ -3,7 +3,7 @@ title: fxmanifest standards
 description: Standards for FiveM/RedM resource manifest files
 globs: ["**/fxmanifest.lua"]
 alwaysApply: true
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # fxmanifest.lua standards

--- a/rules/performance-rules.mdc
+++ b/rules/performance-rules.mdc
@@ -3,7 +3,7 @@ title: Performance rules
 description: Performance optimization rules for CFX resources
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
 alwaysApply: true
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # CFX performance rules

--- a/rules/security-best-practices.mdc
+++ b/rules/security-best-practices.mdc
@@ -3,7 +3,7 @@ title: Security best practices
 description: Security rules for FiveM/RedM resource development
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
 alwaysApply: false
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # CFX security best practices

--- a/skills/client-server-patterns/SKILL.md
+++ b/skills/client-server-patterns/SKILL.md
@@ -2,7 +2,7 @@
 title: Client-Server Patterns
 description: Correct patterns for client/server scripting in Lua, JavaScript, and C# for CFX
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # Client-Server Patterns

--- a/skills/database-integration/SKILL.md
+++ b/skills/database-integration/SKILL.md
@@ -2,7 +2,7 @@
 title: Database Integration
 description: Guide database setup and queries for FiveM/RedM resources using oxmysql
 globs: ["**/*.lua", "**/*.js", "**/*.sql"]
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # Database Integration

--- a/skills/framework-detection/SKILL.md
+++ b/skills/framework-detection/SKILL.md
@@ -2,7 +2,7 @@
 title: Framework Detection
 description: Detect which framework a project is using and adapt code generation accordingly
 globs: ["**/fxmanifest.lua", "**/*.lua"]
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # Framework Detection

--- a/skills/fxmanifest/SKILL.md
+++ b/skills/fxmanifest/SKILL.md
@@ -2,7 +2,7 @@
 title: fxmanifest.lua Expert
 description: Expert knowledge on writing and editing FiveM/RedM resource manifest files
 globs: ["**/fxmanifest.lua"]
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # fxmanifest.lua Expert

--- a/skills/native-functions/SKILL.md
+++ b/skills/native-functions/SKILL.md
@@ -2,7 +2,7 @@
 title: Native Function Lookup
 description: Help the AI agent find and correctly use FiveM and RedM native functions
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # Native Function Lookup

--- a/skills/nui-development/SKILL.md
+++ b/skills/nui-development/SKILL.md
@@ -2,7 +2,7 @@
 title: NUI Development
 description: Guide development of NUI (in-game web UI) interfaces for FiveM and RedM
 globs: ["**/fxmanifest.lua", "**/*.html", "**/*.css"]
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # NUI Development

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -2,7 +2,7 @@
 title: Performance Optimization
 description: CFX-specific performance best practices for FiveM and RedM resources
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # Performance Optimization

--- a/skills/resource-scaffolding/SKILL.md
+++ b/skills/resource-scaffolding/SKILL.md
@@ -2,7 +2,7 @@
 title: Resource Scaffolding
 description: Guide the AI agent through creating a new FiveM or RedM resource from scratch
 globs: ["**/fxmanifest.lua"]
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # Resource Scaffolding

--- a/skills/state-bags/SKILL.md
+++ b/skills/state-bags/SKILL.md
@@ -2,7 +2,7 @@
 title: State Bags
 description: Modern data synchronization using State Bags instead of TriggerClientEvent patterns
 globs: ["**/*.lua", "**/*.js", "**/*.cs"]
-standards-version: 1.6.3
+standards-version: 1.7.0
 ---
 
 # State Bags


### PR DESCRIPTION
Phase 2 Session D canary PR. Validates the diff pattern for the v1.7.0 ecosystem rollout before parallel execution across the remaining tool repos.

## Two changes

1. Adds the `drift-check` job to `validate.yml`. The job runs the meta-repo's drift checker (composite action at `@v1.7`) in `mode: self` against this repo's checkout. Provides PR-time feedback when future changes drift from ecosystem standards.

2. Bumps `standards-version` signals across all `SKILL.md`, `.mdc`, and `AGENTS.md` files from `1.6.3` to `1.7.0`. Aligns with the v1.7 standards generation per Phase 2 Decision 1 (same-major-minor signal granularity).

The PR's own `drift-check` run should pass green because both changes arrive in the same diff: the signal bump resolves the drift that the new check would otherwise report.

## Why now

Prerequisite work that landed first:

- v1.7.4: composite action propagates checker `rc=1` to caller (#15)
- v1.7.5: `cursor-plugin` type skips `stale-counts` to suppress narrative-aggregate noise (#16; interim resolution of #12)
- prereq batch (already merged here): `release.yml` paths-ignore expanded to exclude agent files

## Test plan

- [x] Local pre-flight: `python cli.py --local . --config <meta>/standards/drift-checker.config.json` reports 0 errors, 0 warnings
- [ ] PR's drift-check job passes green
- [ ] Existing CFX validate jobs (validate-content, validate-counts, etc.) still pass
- [ ] After merge: `release.yml` does NOT trigger (per the paths-ignore prereq)

## Related

- TMHSDigital/Developer-Tools-Directory#1 Phase 2 Session D
- v1.7 floating tag now points at v1.7.5
