### PR TITLE
fix: replace inline python3 -c blocks with heredoc in three workflows

### DIFF
--- a/.github/workflows/update-docs-index.yml
+++ b/.github/workflows/update-docs-index.yml
@@ -23,7 +23,8 @@ jobs:
         run: python3 .github/scripts/build_docs_index.py
 
       - name: Validate index
-        run: python3 -c "
+        run: |
+          python3 << 'EOF'
           import json
           data = json.load(open('mcp-server/data/docs_index.json'))
           assert isinstance(data, list), 'Expected array'
@@ -34,7 +35,7 @@ jobs:
               assert 'section' in page, f'Missing section'
               assert 'snippet' in page, f'Missing snippet'
           print(f'Docs index: {len(data)} pages validated')
-          "
+          EOF
 
       - name: Check for changes
         id: diff

--- a/.github/workflows/update-natives.yml
+++ b/.github/workflows/update-natives.yml
@@ -38,7 +38,8 @@ jobs:
         run: python3 .github/scripts/transform_natives.py
 
       - name: Validate transformed data
-        run: python3 -c "
+        run: |
+          python3 << 'EOF'
           import json
 
           for game in ['gta5', 'rdr3']:
@@ -48,13 +49,13 @@ jobs:
               assert len(data) > 0, f'{path}: empty array'
               for n in data:
                   assert 'name' in n, f'{path}: missing name'
-                  assert 'hash' in n, f'{path}: missing hash in {n[\"name\"]}'
-                  assert 'side' in n, f'{path}: missing side in {n[\"name\"]}'
-                  assert 'category' in n, f'{path}: missing category in {n[\"name\"]}'
-                  assert 'params' in n, f'{path}: missing params in {n[\"name\"]}'
-                  assert isinstance(n.get('deprecated'), bool), f'{path}: deprecated must be bool in {n[\"name\"]}'
+                  assert 'hash' in n, f'{path}: missing hash in {n["name"]}'
+                  assert 'side' in n, f'{path}: missing side in {n["name"]}'
+                  assert 'category' in n, f'{path}: missing category in {n["name"]}'
+                  assert 'params' in n, f'{path}: missing params in {n["name"]}'
+                  assert isinstance(n.get('deprecated'), bool), f'{path}: deprecated must be bool in {n["name"]}'
               print(f'{game}: {len(data)} natives validated')
-          "
+          EOF
 
       - name: Check for changes
         id: diff

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,50 +23,54 @@ jobs:
         run: python3 -c "import json; json.load(open('.cursor/mcp.json'))"
 
       - name: Validate natives_gta5.json
-        run: python3 -c "
+        run: |
+          python3 << 'EOF'
           import json
           data = json.load(open('mcp-server/data/natives_gta5.json'))
           assert isinstance(data, list), 'Expected array'
           for n in data:
               assert 'name' in n, f'Missing name in {n}'
-              assert 'hash' in n, f'Missing hash in {n.get(\"name\", \"unknown\")}'
-              assert 'side' in n, f'Missing side in {n.get(\"name\", \"unknown\")}'
-              assert 'category' in n, f'Missing category in {n.get(\"name\", \"unknown\")}'
-              assert isinstance(n.get('deprecated'), bool), f'deprecated must be bool in {n.get(\"name\", \"unknown\")}'
-              assert n.get('examples') is None or isinstance(n.get('examples'), str), f'examples must be string or null in {n.get(\"name\", \"unknown\")}'
+              assert 'hash' in n, f'Missing hash in {n.get("name", "unknown")}'
+              assert 'side' in n, f'Missing side in {n.get("name", "unknown")}'
+              assert 'category' in n, f'Missing category in {n.get("name", "unknown")}'
+              assert isinstance(n.get('deprecated'), bool), f'deprecated must be bool in {n.get("name", "unknown")}'
+              assert n.get('examples') is None or isinstance(n.get('examples'), str), f'examples must be string or null in {n.get("name", "unknown")}'
           print(f'GTA5 natives: {len(data)} entries validated')
-          "
+          EOF
 
       - name: Validate natives_rdr3.json
-        run: python3 -c "
+        run: |
+          python3 << 'EOF'
           import json
           data = json.load(open('mcp-server/data/natives_rdr3.json'))
           assert isinstance(data, list), 'Expected array'
           for n in data:
               assert 'name' in n, f'Missing name in {n}'
-              assert 'hash' in n, f'Missing hash in {n.get(\"name\", \"unknown\")}'
-              assert 'side' in n, f'Missing side in {n.get(\"name\", \"unknown\")}'
-              assert 'category' in n, f'Missing category in {n.get(\"name\", \"unknown\")}'
-              assert isinstance(n.get('deprecated'), bool), f'deprecated must be bool in {n.get(\"name\", \"unknown\")}'
-              assert n.get('examples') is None or isinstance(n.get('examples'), str), f'examples must be string or null in {n.get(\"name\", \"unknown\")}'
+              assert 'hash' in n, f'Missing hash in {n.get("name", "unknown")}'
+              assert 'side' in n, f'Missing side in {n.get("name", "unknown")}'
+              assert 'category' in n, f'Missing category in {n.get("name", "unknown")}'
+              assert isinstance(n.get('deprecated'), bool), f'deprecated must be bool in {n.get("name", "unknown")}'
+              assert n.get('examples') is None or isinstance(n.get('examples'), str), f'examples must be string or null in {n.get("name", "unknown")}'
           print(f'RDR3 natives: {len(data)} entries validated')
-          "
+          EOF
 
       - name: Validate events.json
-        run: python3 -c "
+        run: |
+          python3 << 'EOF'
           import json
           data = json.load(open('mcp-server/data/events.json'))
           assert isinstance(data, list), 'Expected array'
           for e in data:
               assert 'name' in e, f'Missing name in {e}'
-              assert 'side' in e, f'Missing side in {e.get(\"name\", \"unknown\")}'
-              assert 'framework' in e, f'Missing framework in {e.get(\"name\", \"unknown\")}'
-              assert 'game' in e, f'Missing game in {e.get(\"name\", \"unknown\")}'
+              assert 'side' in e, f'Missing side in {e.get("name", "unknown")}'
+              assert 'framework' in e, f'Missing framework in {e.get("name", "unknown")}'
+              assert 'game' in e, f'Missing game in {e.get("name", "unknown")}'
           print(f'Events: {len(data)} entries validated')
-          "
+          EOF
 
       - name: Validate docs_index.json
-        run: python3 -c "
+        run: |
+          python3 << 'EOF'
           import json
           data = json.load(open('mcp-server/data/docs_index.json'))
           assert isinstance(data, list), 'Expected array'
@@ -75,7 +79,7 @@ jobs:
               assert 'url' in page, f'Missing url'
               assert 'section' in page, f'Missing section'
           print(f'Docs index: {len(data)} pages validated')
-          "
+          EOF
 
   validate-plugin-manifest:
     name: Validate plugin manifest
@@ -84,7 +88,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check required manifest fields
-        run: python3 -c "
+        run: |
+          python3 << 'EOF'
           import json
           m = json.load(open('.cursor-plugin/plugin.json'))
           required = ['name', 'displayName', 'description', 'version', 'author', 'license', 'skills', 'rules']
@@ -93,25 +98,27 @@ jobs:
           import re
           assert re.match(r'^[a-z0-9]+(-[a-z0-9]+)*$', m['name']), 'name must be lowercase kebab-case'
           print('Plugin manifest valid')
-          "
+          EOF
 
       - name: Check skill files exist
-        run: python3 -c "
+        run: |
+          python3 << 'EOF'
           import json, os
           m = json.load(open('.cursor-plugin/plugin.json'))
           for skill in m.get('skills', []):
               assert os.path.exists(skill), f'Skill not found: {skill}'
-          print(f'All {len(m[\"skills\"])} skill files exist')
-          "
+          print(f'All {len(m["skills"])} skill files exist')
+          EOF
 
       - name: Check rule files exist
-        run: python3 -c "
+        run: |
+          python3 << 'EOF'
           import json, os
           m = json.load(open('.cursor-plugin/plugin.json'))
           for rule in m.get('rules', []):
               assert os.path.exists(rule), f'Rule not found: {rule}'
-          print(f'All {len(m[\"rules\"])} rule files exist')
-          "
+          print(f'All {len(m["rules"])} rule files exist')
+          EOF
 
   validate-content:
     name: Validate content quality
@@ -151,7 +158,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check skill and snippet counts match plugin.json
-        run: python3 << 'EOF'
+        run: |
+          python3 << 'EOF'
           import json, os, sys
 
           m = json.load(open('.cursor-plugin/plugin.json'))
@@ -197,7 +205,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check fxmanifest.lua files have required fields
-        run: python3 << 'EOF'
+        run: |
+          python3 << 'EOF'
           import os, re, sys
 
           errors = []


### PR DESCRIPTION
Fixes #5, #6, #7. Replaces unquoted multiline `python3 -c "..."` blocks with `run: |` block scalars containing python3 heredocs (`python3 << 'EOF' ... EOF`) across all three workflow files.

## What was broken

The `python3 -c "..."` form was parsed by YAML as a plain scalar, but the body's `for n in data:` and `if condition:` lines contain colons that YAML interprets as mapping-key separators. Result: scanner error before any job ran.

Per CFX#5 the first scanner error was at `validate.yml` line 30 column 24. The full repro was 5 of 5 most recent runs `completed/failure`, since 2026-04-08.

## What this PR does

- `validate.yml`: 7 multiline `python3 -c` blocks replaced with heredocs. Also fixes 2 pre-existing latent bugs in `validate-counts` and `validate-templates` jobs that used `run: python3 << 'EOF'` without the `run: |` marker (would have folded python into one line at runtime; previously unreachable because earlier scanner errors halted parsing).
- `update-natives.yml`: 1 multiline `python3 -c` block replaced with heredoc.
- `update-docs-index.yml`: 1 multiline `python3 -c` block replaced with heredoc.

Net diff: 3 files changed, 51 insertions, 40 deletions.

## Local verification

- All 3 files parse cleanly under PyYAML `safe_load`, with newlines preserved in every script body (verified post-edit).
- Every python validation block runs successfully against the actual repo data:
  - `natives_gta5.json`: 6338 entries pass schema.
  - `natives_rdr3.json`: 5875 entries pass schema.
  - `events.json`: 101 entries pass schema.
  - `docs_index.json`: 82 pages pass schema (with `snippet` field, which the stricter `update-docs-index.yml` validator requires).
  - `validate-counts`: 9 skills, 6 rules, 24 snippets, 11 templates all match `plugin.json` and `README.md`.
  - `validate-templates`: all `fxmanifest.lua` templates have `fx_version`, `games`, `'cerulean'`.
- One representative heredoc was exercised end-to-end via `bash` to confirm the heredoc-to-python pipe works. Output matched expectations.

So once this lands, the validate job should go green for the first time since 2026-04-08, and the two scheduled `update-*` workflows will actually run their validation steps when next triggered.

## Context

Surfaced during Phase 2 Session D D-1 canary (TMHSDigital/Developer-Tools-Directory#1 close-out) on 2026-04-25 when the first drift-check job to ever land on CFX revealed validate.yml had been silently broken for weeks. The audit then surfaced the same pattern in `update-natives.yml` and `update-docs-index.yml`, which produced #6 and #7.

The drift-check workflow itself is unaffected (lives in standalone `drift-check.yml`, was the deliberate Phase 2 pivot away from sibling-job-in-validate.yml precisely because of #5).
