### PR TITLE
feat: integrate release-doc-sync to keep release docs aligned

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,13 @@ jobs:
           print(f'Updated README.md badge to {new_version}')
           "
 
+      - name: Sync release docs
+        if: steps.check.outputs.skip == 'false'
+        uses: TMHSDigital/Developer-Tools-Directory/.github/actions/release-doc-sync@v1.0
+        with:
+          plugin-version: ${{ steps.new.outputs.version }}
+          previous-version: ${{ steps.current.outputs.version }}
+
       - name: Generate release notes from commits
         if: steps.check.outputs.skip == 'false'
         id: notes
@@ -174,7 +181,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .cursor-plugin/plugin.json README.md
+          git add .cursor-plugin/plugin.json README.md CHANGELOG.md
           git commit -m "chore: bump version to ${{ steps.new.outputs.version }} [skip ci]"
           git push
 


### PR DESCRIPTION
Integrates the `release-doc-sync@v1.0` composite action into `release.yml`. After `plugin.json` is bumped on auto-release, the action prepends a stub entry to `CHANGELOG.md` for the new version.

This repo does not ship `CLAUDE.md` or `ROADMAP.md`, so the action's CLAUDE/ROADMAP edits are no-ops here (the action reports them as `missing` and exits cleanly).

## One small adjustment to `git add`

This repo's existing "Commit version bump" step uses

```sh
git add .cursor-plugin/plugin.json README.md
```

rather than the `git add -A` pattern used by Docker / Steam / Home-Lab / Monday. To make sure the action's CHANGELOG prepend actually lands in the release commit, this PR adds `CHANGELOG.md` to that list:

```sh
git add .cursor-plugin/plugin.json README.md CHANGELOG.md
```

Without this change the action would run successfully but its sole useful output for this repo would be silently discarded.

Phase 2c parallel rollout following the Docker smoke test (verified at `v1.8.2` of `release-doc-sync`).

The PR's own CI does not exercise `release-doc-sync` directly. Validation happens on the next auto-release post-merge.

Refs `TMHSDigital/Developer-Tools-Directory#5`.
