### PR TITLE
chore: migrate release-doc-sync pin from @v1.0 to @v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Sync release docs
         if: steps.check.outputs.skip == 'false'
-        uses: TMHSDigital/Developer-Tools-Directory/.github/actions/release-doc-sync@v1.0
+        uses: TMHSDigital/Developer-Tools-Directory/.github/actions/release-doc-sync@v1
         with:
           plugin-version: ${{ steps.new.outputs.version }}
           previous-version: ${{ steps.current.outputs.version }}


### PR DESCRIPTION
One-line migration: bumps the `release-doc-sync` action pin from `@v1.0` to `@v1`.

The `v1` floating tag is auto-maintained by the meta-repo's `release.yml` since DTD#14 landed (PR #26). `v1.0` was a legacy float created before that automation existed.

Once all 6 consumer repos migrate, `v1.0` will be deleted in the meta-repo.

Refs TMHSDigital/Developer-Tools-Directory#27.
