### PR TITLE
chore: add github-actions ecosystem to dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Refs TMHSDigital/Developer-Tools-Directory#31. Adds dependabot coverage for the github-actions ecosystem so future deprecations surface as PRs rather than manual audits.

Made with [Cursor](https://cursor.com)