### PR TITLE
fix: backfill CONTRIBUTING.md and CLAUDE.md per ecosystem standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+<!-- standards-version: 1.9.4 -->
+
+# CLAUDE.md
+
+Project documentation for Claude Code and AI assistants working on this repository.
+
+## Project Overview
+
+CFX Developer Tools is a Cursor IDE plugin for FiveM and RedM (CFX) resource development. It includes 9 skills, 6 rules, 24 code snippets, 11 starter templates, and a companion Python MCP server with 6 tools for resource scaffolding, native lookup, manifest generation, framework detection, and live doc and event search.
+
+**Works with:** Cursor (plugin), Claude Code (terminal and in-editor), and any MCP-compatible client.
+
+This is a monorepo. Skills, rules, snippets, templates, and the companion MCP server live in the same repository because CFX resource development crosses all of those layers in a single workflow.
+
+**Version:** 0.8.2
+**License:** CC-BY-NC-ND-4.0
+**Author:** TMHSDigital
+
+## Plugin Architecture
+
+```
+CFX-Developer-Tools/
+  .cursor-plugin/
+    plugin.json              # Plugin manifest (version, skills, rules)
+  skills/
+    <skill-name>/
+      SKILL.md               # One skill per directory (kebab-case)
+  rules/
+    <rule-name>.mdc          # Cursor rule files
+  snippets/                  # Lua, JS, C# code snippets
+  templates/                 # Resource starter templates
+  mcp-server/
+    server.py                # MCP server entry point (Python, FastMCP)
+    tools/                   # One module per tool
+    data/                    # Native databases, doc index, events
+    requirements.txt
+  docs/                      # MkDocs Material site
+  .github/
+    workflows/               # CI / release / native-update / docs-index automation
+```
+
+## Skills (9)
+
+| Skill | Description |
+|-------|-------------|
+| `resource-scaffolding` | Generate a complete CFX resource skeleton (fxmanifest, client/server entries, NUI scaffolding) |
+| `native-functions` | Look up GTA5, RDR3, and CFX-platform native functions with parameter and return types |
+| `fxmanifest` | Author and validate `fxmanifest.lua` (fx_version, games, dependencies, NUI files, exports) |
+| `client-server-patterns` | Event routing, NetEvents vs Events, callback patterns, state synchronization |
+| `framework-detection` | Detect ESX / QBCore / Qbox / ox_core / VORP / RSG / standalone from a workspace |
+| `performance-optimization` | Threads, OneSync, native batching, NUI message rate, and resource memory budget |
+| `nui-development` | NUI lifecycle, message routing, asset loading, callbacks, and Vite / Svelte integration |
+| `database-integration` | oxmysql, ghmattimysql, MariaDB connection patterns, prepared statements, migration flow |
+| `state-bags` | StateBag CRUD, replicated vs local, change handlers, and replacement of legacy SetX patterns |
+
+## Rules (6)
+
+| Rule | Scope | Description |
+|------|-------|-------------|
+| `cfx-lua-conventions.mdc` | `**/*.lua` | Flag CFX-specific Lua antipatterns (string concat in tight loops, missing `local`, deprecated natives) |
+| `cfx-javascript-conventions.mdc` | `**/*.js`, `**/*.ts` | Flag JS/TS antipatterns in CFX context (NUI message routing, async event handlers) |
+| `cfx-csharp-conventions.mdc` | `**/*.cs` | Flag C# patterns specific to FiveM (BaseScript, Tick handlers, async exports) |
+| `fxmanifest-standards.mdc` | `**/fxmanifest.lua` | Flag missing `fx_version`, `games`, `'cerulean'` declarations and deprecated directives like `lua54 'yes'` |
+| `security-best-practices.mdc` | Global | Flag hardcoded API keys, server-trust violations, unsafe NUI callbacks, missing input validation |
+| `performance-rules.mdc` | CFX resource files | Flag thread blockers, unbounded loops, missing `Wait()` in `CreateThread`, expensive natives in tight loops |
+
+## MCP Server (6 tools)
+
+The companion MCP server is Python-based (FastMCP). It exposes CFX-aware tools that read from local data files (`mcp-server/data/`) and the working tree.
+
+| Tool | Description |
+|------|-------------|
+| `scaffold_resource_tool` | Generate a complete CFX resource (fxmanifest, client/server entries, optional NUI) from a name and framework selection |
+| `lookup_native_tool` | Search GTA5, RDR3, and CFX-platform natives by name, hash, or namespace; returns parameters, return type, and usage notes |
+| `generate_manifest_tool` | Author or update an `fxmanifest.lua` with required keys, dependencies, and NUI declarations |
+| `search_events_tool` | Search the indexed CFX events database for canonical net-event and exports usage patterns |
+| `detect_framework_tool` | Detect ESX / QBCore / Qbox / ox_core / VORP / RSG / standalone from a workspace path |
+| `search_docs_tool` | Search the indexed `docs.fivem.net` snapshot for parameters, gotchas, and code samples |
+
+## Development Workflow
+
+### Plugin development (symlink)
+
+**macOS / Linux:**
+```bash
+ln -s "$(pwd)" ~/.cursor/plugins/cfx-developer-tools
+```
+
+**Windows (PowerShell as Admin):**
+```powershell
+New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\.cursor\plugins\cfx-developer-tools" -Target (Get-Location)
+```
+
+### MCP server development
+
+```bash
+cd mcp-server
+pip install -r requirements.txt
+python server.py
+```
+
+### Running validation
+
+```bash
+# JSON schema and content-count checks (run by CI)
+python .github/scripts/validate_plugin.py
+
+# Native database refresh (manual; usually run by update-natives.yml)
+python .github/scripts/transform_natives.py
+```
+
+## Release Workflow
+
+Releases are automated. The `release.yml` workflow:
+
+1. Reads conventional commits since the last tag.
+2. Computes the next semver bump (PATCH for `fix:`, MINOR for `feat:`, MAJOR for `BREAKING CHANGE`).
+3. Updates `plugin.json` `version` and the README version badge.
+4. Creates the tag, the GitHub Release, and floating major / minor tags.
+5. Invokes `release-doc-sync` to update `**Version:**` in this file and prepend a CHANGELOG entry.
+6. Syncs the GitHub repo "About" section (description, homepage, topics) with live artifact counts.
+
+Do not hand-edit `plugin.json` `version`, the README badge, or the `**Version:**` line above. The release pipeline owns them.
+
+## Key Conventions
+
+- **No em dashes.** Use regular dashes (`-`) or rewrite the sentence. CI flags em and en dashes in markdown.
+- **No hardcoded credentials.** Use environment variables, server-side `convar`s, or secrets stores. CI flags suspicious patterns.
+- **Skill frontmatter:** `name` (matching directory) and `description` only.
+- **Rule frontmatter:** `description`, `alwaysApply`, and `globs` (when path-scoped).
+- **Snippets:** must compile or load cleanly inside a CFX resource (Lua / JS / C#), no placeholder credentials.
+- **Templates:** every `fxmanifest.lua` must declare `fx_version`, `games`, and `'cerulean'`. Avoid `lua54 'yes'` (deprecated; use `lua54 true`).
+- **MCP tool naming:** snake_case Python functions decorated with `@mcp.tool()`, suffix `_tool` for clarity in agent prompts.
+
+## CFX Native Reference Quick Links
+
+| Resource | Use |
+|----------|-----|
+| `runtime.fivem.net/doc/natives.json` | GTA5 native database upstream |
+| `runtime.fivem.net/doc/natives_rdr3.json` | RDR3 native database upstream |
+| `docs.fivem.net` | Authoritative scripting reference, refreshed monthly via `update-docs-index.yml` |
+| `mcp-server/data/natives_gta5.json` | Local GTA5 native lookup index |
+| `mcp-server/data/natives_rdr3.json` | Local RDR3 native lookup index |
+| `mcp-server/data/events.json` | Indexed canonical CFX event names and payloads |
+| `mcp-server/data/docs_index.json` | Indexed `docs.fivem.net` snippets for offline search |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,144 @@
+# Contributing to CFX Developer Tools
+
+Thanks for helping improve this plugin. This document describes how to set up locally, extend skills and rules, and submit changes.
+
+## Getting Started
+
+1. **Fork** the repository on GitHub.
+2. **Clone** your fork:
+
+   ```bash
+   git clone https://github.com/<your-username>/CFX-Developer-Tools.git
+   cd CFX-Developer-Tools
+   ```
+
+3. **Create a branch** for your work:
+
+   ```bash
+   git checkout -b your-feature-name
+   ```
+
+## Local Development
+
+Install the plugin from your working copy so Cursor loads your changes.
+
+Symlink the repo into the local plugins directory: `~/.cursor/plugins/local/cfx-developer-tools/` (create parent folders if needed).
+
+**Windows (PowerShell):**
+
+```powershell
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.cursor\plugins\local\cfx-developer-tools" | Out-Null
+cmd /c mklink /J "$env:USERPROFILE\.cursor\plugins\local\cfx-developer-tools\CFX-Developer-Tools" (Get-Location)
+```
+
+Adjust the final path if your clone lives elsewhere.
+
+**macOS / Linux:**
+
+```bash
+mkdir -p ~/.cursor/plugins/local/cfx-developer-tools
+ln -s "$(pwd)" ~/.cursor/plugins/local/cfx-developer-tools/CFX-Developer-Tools
+```
+
+Restart Cursor after linking so it picks up the plugin.
+
+## Plugin Structure
+
+The repo is organized as a Cursor plugin with **9 skills** and **6 rules**, plus snippets, templates, and a companion MCP server.
+
+```text
+.cursor-plugin/
+  plugin.json
+skills/
+  <skill-name-kebab>/
+    SKILL.md
+rules/
+  <rule-name>.mdc
+snippets/
+templates/
+mcp-server/
+  server.py
+  tools/
+  data/
+docs/
+.github/
+  workflows/
+```
+
+- **`plugin.json`** - manifest (name, version, paths to skills/rules).
+- **`skills/`** - one directory per skill; each contains `SKILL.md`.
+- **`rules/`** - Cursor rules as `.mdc` files with YAML frontmatter.
+- **`snippets/`** - Lua / JS / C# code snippets for FiveM and RedM scripting patterns.
+- **`templates/`** - resource starter templates (standalone, ESX, QBCore, Qbox, ox_core, VORP, RSG, JS, C#, NUI Vite, NUI Svelte).
+- **`mcp-server/`** - Python MCP server exposing CFX-aware tools (resource scaffolding, native lookup, manifest generation, framework detection, doc and event search).
+
+## Adding a Skill
+
+1. Add a **kebab-case** directory under `skills/`, e.g. `skills/cfx-example-flow/`.
+2. Create **`SKILL.md`** with YAML frontmatter including at least `name` and `description`.
+3. In the body, include these sections (use `##` headings with these titles):
+   - **Trigger** - when the skill should load.
+   - **Required Inputs** - what the agent or user must provide.
+   - **Workflow** - step-by-step guidance.
+   - **Key References** - docs, native names, or repo paths.
+   - **Example Interaction** - short example prompt/response pattern.
+   - **MCP Usage** - when to use the companion MCP server, if relevant.
+   - **Common Pitfalls** - mistakes to avoid (deprecated natives, framework-specific gotchas, NUI message routing, etc.).
+   - **See Also** - links to related skills or rules.
+
+Match tone, formatting, and frontmatter style of existing skills in this repo.
+
+## Adding a Rule
+
+1. Add a **`.mdc`** file under `rules/`, e.g. `rules/cfx-example.mdc`.
+2. Start with YAML **frontmatter**:
+   - `description` - one-line summary for humans and tooling.
+   - `alwaysApply` - `true` or `false` depending on whether the rule should apply globally.
+   - `globs` - optional glob patterns (e.g. `**/*.lua`, `**/fxmanifest.lua`) when the rule is path-scoped.
+
+3. Below the frontmatter, write the rule content in Markdown (constraints, patterns, anti-patterns).
+
+Keep rules focused; prefer linking to a skill for long workflows.
+
+## Adding a Snippet or Template
+
+1. Snippets live under `snippets/` grouped by language (Lua, JS, C#). Each file should be self-contained, runnable in a CFX resource, and free of hardcoded credentials.
+2. Templates live under `templates/`. A new template needs at least an `fxmanifest.lua` (with `fx_version`, `games`, and `'cerulean'`), the canonical client/server entry files, and any framework-specific config the template targets.
+3. Run the validator before opening a PR; the workflow checks `fxmanifest.lua` required keys and rejects deprecated directives like `lua54 'yes'`.
+
+## Pull Request Process
+
+1. **Update docs** if you change behavior, skill lists, snippet counts, or versioning (`README.md`, `CLAUDE.md`, `CHANGELOG.md`, `docs/ROADMAP.md` as appropriate).
+2. **Run validation** locally where possible. CI runs JSON schema checks, kebab-case enforcement, em/en dash detection, deprecated-directive scans, and Python syntax checks for `mcp-server/`.
+3. **Open a PR** against `main` with a clear title and summary of changes. Use a conventional commit prefix (`feat:`, `fix:`, `docs:`, `chore:`).
+4. **Respond to review** feedback; CI must pass before merge.
+
+## Developer Certificate of Origin and Inbound License Grant
+
+This project uses CC-BY-NC-ND-4.0 as its outbound license, which forbids derivatives. Every pull request is a derivative. Contributions are accepted inbound under a broader grant via the Developer Certificate of Origin (DCO), which resolves the conflict so the project can accept and redistribute contributions.
+
+### Required grant
+
+By submitting a contribution to this repository, you certify that you have the right to do so under the Developer Certificate of Origin (DCO) 1.1, and you grant TMHSDigital a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your contribution under the project's current license (CC-BY-NC-ND-4.0) or any successor license chosen by the project.
+
+### DCO sign-off
+
+Every commit in a pull request must have a `Signed-off-by:` trailer matching the commit author:
+
+```
+Signed-off-by: Jane Developer <jane@example.com>
+```
+
+Signing is done at commit time:
+
+```bash
+git commit -s -m "feat: add new skill"
+```
+
+The GitHub DCO App enforces this on every PR.
+
+For the full inbound/outbound model and rationale, see [`standards/licensing.md`](https://github.com/TMHSDigital/Developer-Tools-Directory/blob/main/standards/licensing.md) in the Developer-Tools-Directory meta-repo.
+
+## Code of Conduct
+
+This project follows the guidelines in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). By participating, you agree to uphold them.


### PR DESCRIPTION
Adds CONTRIBUTING.md and CLAUDE.md, both previously absent from this repo.

CONTRIBUTING.md follows the Plaid pattern (post-DTD#46 DCO backfill) with the verbatim grant paragraph and Signed-off-by guidance from standards/licensing.md.

CLAUDE.md includes the `<!-- standards-version: 1.9.4 -->` marker (HTML comment, per the standard) and the `**Version:** 0.8.2` line that release-doc-sync auto-maintains on each release.

Tracks DTD#48 (expanded scope: original issue noted CONTRIBUTING.md only; CLAUDE.md absence surfaced during DTD#47 work). Canary for parallel rollout to Unity which has the same gap.

No code changes. New documentation files only.
