### PR TITLE
fix: stage all release-doc-sync edits in version bump commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .cursor-plugin/plugin.json README.md CHANGELOG.md
+          git add -A
           git commit -m "chore: bump version to ${{ steps.new.outputs.version }} [skip ci]"
           git push
 


### PR DESCRIPTION
Fixes a one-line bug in release.yml's bump-commit step.

Previous step:
`git add .cursor-plugin/plugin.json README.md CHANGELOG.md`

This selectively stages only three paths, discarding any other changes the runner's working tree accumulated during the release run, including release-doc-sync's CLAUDE.md and ROADMAP.md edits.

Result: release-doc-sync ran with `changed: true (CHANGELOG.md CLAUDE.md)` per its action output, but only CHANGELOG.md (one of the three explicitly staged paths) made it into the bump commit. CLAUDE.md edits were destroyed.

Fix: `git add -A` stages everything, matching how the other 5 auto-releasing tool repos (Docker, Home-Lab, Monday, Steam-Cursor, Blender) do it.

Surfaced when CFX's CLAUDE.md `**Version:**` line was found silently stale at 0.8.2 despite plugin.json being at 0.8.3. The drift had been silently accumulating across many releases.

Closes #51. Same fix needs to ship on Unity-Developer-Tools (parallel rollout follows this canary).
