### PR TITLE
fix: normalize standards-version marker in CLAUDE.md to 1.9.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- standards-version: 1.9.4 -->
+<!-- standards-version: 1.9.0 -->
 
 # CLAUDE.md
 


### PR DESCRIPTION
## Summary

Sets `CLAUDE.md` `standards-version` marker from `1.9.4` to `1.9.0` to match the value already carried by `AGENTS.md`, all `skills/*/SKILL.md` files, and all `rules/*.mdc` files.

## Root cause

`CLAUDE.md` did not exist in this repo at the time of the original fleet-wide alignment at `1.9.0`. It was added later via PR #15 ("fix: backfill CONTRIBUTING.md and CLAUDE.md per ecosystem standards"), which used the then-current meta-repo `VERSION` (`1.9.4`) as the stamp value. All other agent files had already been stamped at `1.9.0` in the earlier pass, creating an internal inconsistency within the repo.

This is not a bug in `release-doc-sync` or any script. Release-doc-sync does not touch `standards-version` markers (DTD#1). The inconsistency was a one-off from backfilling a missing file at a different point in time.

## What changes

- `CLAUDE.md` line 1: `<!-- standards-version: 1.9.4 -->` changed to `<!-- standards-version: 1.9.0 -->`
- Nothing else is touched.

## After this merge

This repo will have uniform `standards-version: 1.9.0` across all agent files. A full re-stamp to the current meta-repo VERSION is a separate fleet-wide rollout decision deferred to the maintainer.

The `fix:` prefix will drive a patch version bump on merge via `release.yml`. That is expected and correct.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>