### PR TITLE
chore: stamp standards-version to 1.10.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- standards-version: 1.9.0 -->
+<!-- standards-version: 1.10.0 -->
 
 # AGENTS.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- standards-version: 1.9.0 -->
+<!-- standards-version: 1.10.0 -->
 
 # CLAUDE.md
 


### PR DESCRIPTION
Update CLAUDE.md (and AGENTS.md where present) to mark compliance with ecosystem standards v1.10.0.